### PR TITLE
Replace `QString::sprintf` with `QString::asprintf`

### DIFF
--- a/source/view/geniedialog.cc
+++ b/source/view/geniedialog.cc
@@ -99,14 +99,14 @@ void GenieDialog::decode() {
             NESGameGenieCode ggcode = NESGameGenieCode::create(text);
             NESRawCode rawcode = Decoder::decodeNES(ggcode);
             
-            str.sprintf("%02X", rawcode.getValue());
+            str = QString::asprintf("%02X", rawcode.getValue());
             ui.valueEdit->setText(str);
             
-            str.sprintf("%04X", rawcode.getAddress());
+            str = QString::asprintf("%04X", rawcode.getAddress());
             ui.addressEdit->setText(str);
             
             if (rawcode.hasCompare()) {
-                str.sprintf("%02X", rawcode.getCompare());
+                str = QString::asprintf("%02X", rawcode.getCompare());
                 ui.compareEdit->setText(str);
             } else {
                 ui.compareEdit->clear();
@@ -115,32 +115,32 @@ void GenieDialog::decode() {
             SNESGameGenieCode ggcode = SNESGameGenieCode::create(text);
             SNESRawCode rawcode = Decoder::decodeSNES(ggcode);
             
-            str.sprintf("%02X", rawcode.getValue());
+            str = QString::asprintf("%02X", rawcode.getValue());
             ui.valueEdit->setText(str);
             
-            str.sprintf("%04X", rawcode.getAddress());
+            str = QString::asprintf("%04X", rawcode.getAddress());
             ui.addressEdit->setText(str);
         } else if (system == GENESIS) {
             GenesisGameGenieCode ggcode = GenesisGameGenieCode::create(text);
             GenesisRawCode rawcode = Decoder::decodeGenesis(ggcode);
             
-            str.sprintf("%04X", rawcode.getValue());
+            str = QString::asprintf("%04X", rawcode.getValue());
             ui.valueEdit->setText(str);
             
-            str.sprintf("%04X", rawcode.getAddress());
+            str = QString::asprintf("%04X", rawcode.getAddress());
             ui.addressEdit->setText(str);
         } else if (system == GBGG) {
             GBGGGameGenieCode ggcode = GBGGGameGenieCode::create(text);
             GBGGRawCode rawcode = Decoder::decodeGBGG(ggcode);
             
-            str.sprintf("%02X", rawcode.getValue());
+            str = QString::asprintf("%02X", rawcode.getValue());
             ui.valueEdit->setText(str);
             
-            str.sprintf("%04X", rawcode.getAddress());
+            str = QString::asprintf("%04X", rawcode.getAddress());
             ui.addressEdit->setText(str);
             
             if (rawcode.hasCompare()) {
-                str.sprintf("%02X", rawcode.getCompare());
+                str = QString::asprintf("%02X", rawcode.getCompare());
                 ui.compareEdit->setText(str);
             } else {
                 ui.compareEdit->clear();


### PR DESCRIPTION
`QString::sprintf` was deprecated in Qt 5.14, so replace uses with the static `QString::asprintf` method. This addresses the following warning:

```
  ../source/view/geniedialog.cc:102:17: warning: 'sprintf' is deprecated: Use asprintf(), arg() or QTextStream instead [-Wdeprecated-declarations]
              str.sprintf("%02X", rawcode.getValue());
                  ^
  /opt/local/libexec/qt5/lib/QtCore.framework/Headers/qstring.h:392:5: note: 'sprintf' has been explicitly marked deprecated here
      QT_DEPRECATED_X("Use asprintf(), arg() or QTextStream instead")
      ^
  /opt/local/libexec/qt5/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /opt/local/libexec/qt5/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
```